### PR TITLE
Added Extra Actions for web weaver

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "metapress-plugin-radar",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "metapress-plugin-radar",
-            "version": "1.0.2",
+            "version": "1.0.3",
             "license": "ISC",
             "devDependencies": {
                 "@babel/core": "^7.22.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "metapress-plugin-radar",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "description": "Radar Plugin for MetaPress. It only displays the location of users who are at most 60 meters away from the current user relative to where you are looking at.",
     "main": "js/loader.js",
     "private": true,


### PR DESCRIPTION
Added the following actions that web weaver can perform on this plugin:
- Provide details about the plugin itself
- Get the names and distances information of the user within 60 meters around you (new)
- Enable filtering of the radar, ie allowing only specific users to be seen on the radar (new) 
- Ability to reset Radar to its initial state 